### PR TITLE
Fix Typo

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -68,6 +68,6 @@ func (l Log) SetLevel(n string) {
 
 func New(label string) Logger {
 	return &Log{
-		entry: logrus.WithFields(logrus.Fields{"lebel": label}),
+		entry: logrus.WithFields(logrus.Fields{"label": label}),
 	}
 }


### PR DESCRIPTION
This PR fixes a typo in the `log` package.

`label` was mispelled as `lebel`