### PR TITLE
Added simplified eval js execution from go code

### DIFF
--- a/engine/chrome.go
+++ b/engine/chrome.go
@@ -63,6 +63,10 @@ func (e *ChromeEngine) Bind(name string, fn app.Func) error {
 	})
 }
 
+func (e *ChromeEngine) Eval(js string) {
+	e.ui.Eval(js)
+}
+
 func (e *ChromeEngine) Quit() {
 
 	if e.quited {

--- a/engine/hybrid.go
+++ b/engine/hybrid.go
@@ -26,6 +26,10 @@ func (e HybridEngine) Bind(name string, fn app.Func) error {
 	return e.engine.Bind(name, fn)
 }
 
+func (e *HybridEngine) Eval(js string) {
+	e.engine.Eval(js)
+}
+
 func (e HybridEngine) Quit() {
 	e.engine.Quit()
 }

--- a/engine/webview.go
+++ b/engine/webview.go
@@ -57,6 +57,10 @@ func (e *WebviewEngine) Bind(name string, fn app.Func) error {
 	})
 }
 
+func (e *WebviewEngine) Eval(js string) {
+	e.webview.eval(js)
+}
+
 func (e *WebviewEngine) Quit() {
 
 	if e.quited {

--- a/engine/webview.go
+++ b/engine/webview.go
@@ -58,7 +58,7 @@ func (e *WebviewEngine) Bind(name string, fn app.Func) error {
 }
 
 func (e *WebviewEngine) Eval(js string) {
-	e.webview.eval(js)
+	e.webview.Eval(js)
 }
 
 func (e *WebviewEngine) Quit() {


### PR DESCRIPTION
This commit adds the possibility to execute JS code from the inside go. Solves issue #34 