### PR TITLE
added the ability to use a temporary profile for lorca

### DIFF
--- a/engine/chrome.go
+++ b/engine/chrome.go
@@ -22,10 +22,16 @@ type ChromeEngine struct {
 }
 
 func (e *ChromeEngine) Init() error {
+	var (
+		profile string
+		err     error
+	)
 
-	profile, err := e.app.DataFile("_profile")
-	if err != nil {
-		return err
+	if !boolVal(e.app.EngineConfig["temporary_profile"], false) {
+		profile, err = e.app.DataFile("_profile")
+		if err != nil {
+			return err
+		}
 	}
 
 	e.ui, err = lorca.New(

--- a/engine/utils.go
+++ b/engine/utils.go
@@ -25,6 +25,20 @@ func intVal(i interface{}, def int) int {
 	return v
 }
 
+func boolVal(i interface{}, def bool) bool {
+
+	if i == nil {
+		return def
+	}
+
+	v, ok := i.(bool)
+	if !ok {
+		v = def
+	}
+
+	return v
+}
+
 func newServer(a *app.App) (srv *server.Server, addr string) {
 
 	if a.IsDev() {


### PR DESCRIPTION
There is an [issue](https://github.com/zserge/lorca/issues/155) on windows with lorca where it doesn't close gracefully, causing the app then launch a chrome browser window. By using a temporary profile, chrome doesn't remember that it wasn't closed gracefully and will not complain. 

This is also a bandaid fix for #53 
